### PR TITLE
ログアウト機能の修正

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -6,10 +6,15 @@ import { authRepository } from "@/modules/auth/auth.repository";
 const Sidebar = () => {
   const currentUserStore = useCurrentUserStore();
 
-  const signout = async () => {
+const signout = async () => {
+  try {
     await authRepository.signout();
+  } catch (err) {
+    console.error("ログアウトエラー", err);
+  } finally {
     currentUserStore.set(undefined);
-  };
+  }
+};
 
   return (
     <div className="hidden sm:block w-56 bg-gray-800 text-white h-screen fixed top-14 pt-4">


### PR DESCRIPTION
## 実装内容
ログアウト機能の修正

具体的には
・supabaseの認証セッションが存在しない場合でも、ログアウトをクリックしたらグローバルステートはundefindにするように修正。

## 問題
supabaseの認証セッションが存在しない状態で supabaseの signOut() を呼び出したことによるエラーが本番環境で起きてしまった。

おそらく本番環境でも開発環境でも同じsupabaseを使用しているため、セッションの不整合や 403 Forbidden エラーが起きてしまったと考えられる。