### PR TITLE
サインアウトのhooks化

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,7 +1,9 @@
 import { Link } from "react-router-dom";
 import ReactLogo from "@/assets/react.svg";
+import { useSignout } from "@/modules/auth/use-signout";
 
 const Header = () => {
+  const { signout } = useSignout();
   return (
     <div className="w-full h-16 bg-white shadow-md fixed top-0 flex items-center pl-3 sm:px-6 z-50">
       <div className="flex w-full justify-between">
@@ -15,11 +17,11 @@ const Header = () => {
         <div className="flex sm:hidden items-center pr-6 space-x-4">
 
           {/* ログアウトボタン */}
-          <Link to="/signin">
-            <button className="px-2 py-1 text-sm text-gray-800 border border-gray-400 rounded hover:bg-gray-400">
-              ログアウト
-            </button>
-          </Link>
+          <button
+            onClick={signout}
+            className="px-2 py-1 text-sm text-gray-800 border border-gray-400 rounded hover:bg-gray-400">
+            ログアウト
+          </button>
 
           {/* 顧客登録ボタン */}
           <Link to="/create">
@@ -27,7 +29,7 @@ const Header = () => {
               ＋顧客登録
             </button>
           </Link>
-          
+
         </div>
       </div>
     </div>

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -1,23 +1,13 @@
 import { Link, useLocation } from "react-router-dom";
 import UserItem from "./UserItem";
 import { useCurrentUserStore } from "@/modules/auth/current-user.state";
-import { authRepository } from "@/modules/auth/auth.repository";
+import { useSignout } from "@/modules/auth/use-signout";
 
 const Sidebar = () => {
   const currentUserStore = useCurrentUserStore();
+  const { signout } = useSignout();
   // 現在のパスを取得
   const location = useLocation();
-
-  const signout = async () => {
-    try {
-      await authRepository.signout();
-    } catch (err) {
-      console.error("ログアウトエラー", err);
-    } finally {
-      currentUserStore.set(undefined);
-    }
-  };
-
   const isActive = (path: string) => location.pathname === path;
 
   return (

--- a/src/modules/auth/use-signout.ts
+++ b/src/modules/auth/use-signout.ts
@@ -1,0 +1,21 @@
+import { useNavigate } from "react-router-dom";
+import { authRepository } from "./auth.repository";
+import { useCurrentUserStore } from "./current-user.state";
+
+export const useSignout = () => {
+  const navigate = useNavigate();
+  const currentUserStore = useCurrentUserStore();
+
+  const signout = async () => {
+    try {
+      await authRepository.signout();
+    } catch (err) {
+      console.error("ログアウトエラー", err);
+    } finally {
+      currentUserStore.set(undefined);
+      navigate("/signin");
+    }
+  };
+
+  return { signout };
+};


### PR DESCRIPTION
## 実装内容
サインアウトのhooks化

具体的には
・modules/auth/use-signout.ts にuseSignoutを作り、sidebar と header で使いまわせる様にログアウト機能を実装。

## メモ
**ディレクトリ構成の注意**
・hooksは 汎用的なカスタムフック をまとめる場所。
・今回の signout は authRepository や currentUserStore に依存してるので、「auth専用ロジック」。