### PR TITLE
会社名でも検索可能に変更

### DIFF
--- a/src/components/customers/CustomerList/SearchBox.tsx
+++ b/src/components/customers/CustomerList/SearchBox.tsx
@@ -1,17 +1,25 @@
 import React from "react";
+import { Search } from "lucide-react";
 
 interface SearchBoxProps {
+  // 入力欄に表示する現在の文字列
   searchQuery: string;
+  // 文字を入力したときに呼び出されるコールバック関数
   setSearchQuery: (query: string) => void;
 }
 
 const SearchBox: React.FC<SearchBoxProps> = ({ searchQuery, setSearchQuery }) => {
   return (
-    <div className="mb-4">
+    <div className="relative mb-4">
+
+      {/* 虫眼鏡アイコンを絶対配置 */}
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+
       <input
         type="text"
-        className="w-full p-2 rounded-md border border-gray-300"
-        placeholder="顧客名で検索"
+        className="w-full pl-10 pr-3 py-2 rounded-md border border-gray-300 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+        placeholder="顧客名や会社名で検索"
+        aria-label="顧客名や会社名で検索"
         value={searchQuery}
         onChange={(e) => setSearchQuery(e.target.value)}
       />

--- a/src/components/customers/CustomerList/SortButtons.tsx
+++ b/src/components/customers/CustomerList/SortButtons.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 interface SortButtonsProps {
+  // リテラル型のユニオン型にして絞ることで予期しない値を防げる。
   sortOrder: "name" | "created_at";
   setSortOrder: (order: "name" | "created_at") => void;
 }

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -1,13 +1,18 @@
 import { useState } from "react";
 import { CustomerTypes } from "@/types/customer";
 
-export const useSearch = (data: CustomerTypes[], queryKey: "name" | "company") => {
+export const useSearch = (data: CustomerTypes[]) => {
   const [searchQuery, setSearchQuery] = useState<string>("");
 
   // 検索結果を取得
-  const filteredData = data.filter((item) =>
-    item[queryKey].includes(searchQuery)
-  );
+  // dataという配列から一つずつオブジェクト(customer)を取り出して、customerのnameかcompanyにsearchQuery（入力された情報）が含まれているかをチェックして、その条件を満たす要素だけを抜き出して、新しい配列（filteredData）を作っている。
+  const filteredData = data.filter((customer) => {
+    const query = searchQuery.toLowerCase();
+    return (
+      customer.name.toLowerCase().includes(query) ||
+      customer.company.toLowerCase().includes(query)
+    );
+  });
 
   return { searchQuery, setSearchQuery, filteredData };
 };

--- a/src/lib/sortCustomers.ts
+++ b/src/lib/sortCustomers.ts
@@ -6,6 +6,7 @@ export const sortCustomers = (
 ): CustomerTypes[] => {
   return [...customers].sort((a, b) => {
     if (sortOrder === "name") {
+      // localeCompareは文字列をロケールに基づいて比較するためのJSメソッド
       return a.furigana.localeCompare(b.furigana, "ja", { sensitivity: "base" });
     } else {
       return new Date(b.created_at!).getTime() - new Date(a.created_at!).getTime();

--- a/src/pages/customers/index.tsx
+++ b/src/pages/customers/index.tsx
@@ -9,15 +9,18 @@ import { Customer } from "@/modules/customers/customer.entity";
 // ★ Supabaseから取得する関数をimport
 
 const Customers = () => {
+  // 顧客データを格納
   const [customers, setCustomers] = useState<Customer[]>([]);
+  // 並び順の基準（name または created_at）
   const [sortOrder, setSortOrder] = useState<"name" | "created_at">("name");
 
-  // 顧客一覧の取得
+  // Supabaseから顧客一覧の取得
   useEffect(() => {
     const fetchCustomers = async () => {
       try {
         const data = await customerRepository.getAll();
-        setCustomers(data); // ★ 取得データをセット
+        // 取得データをセット(状態更新)
+        setCustomers(data);
       } catch (err) {
         console.error("顧客データの取得に失敗しました", err);
       }
@@ -26,12 +29,16 @@ const Customers = () => {
     fetchCustomers();
   }, []);
 
-  const { searchQuery, setSearchQuery, filteredData } = useSearch(customers, "name");
+  // customers（顧客リスト）と検索対象（"name"）をuseSearchに送って検索する。
+  const { searchQuery, setSearchQuery, filteredData } = useSearch(customers);
+  // 検索された顧客データ（filteredData）と並び替える基準（sortOrder）をsortCustomersに送って並び替える。
   const sortedCustomers = sortCustomers(filteredData, sortOrder);
 
   return (
     <main className="flex-1 min-h-screen bg-gray-100 p-6 pt-20 sm:pl-64 overflow-y-auto">
+
       <SearchBox searchQuery={searchQuery} setSearchQuery={setSearchQuery} />
+
       <SortButtons sortOrder={sortOrder} setSortOrder={setSortOrder} />
 
       {sortedCustomers.length === 0 ? (


### PR DESCRIPTION
## 実装内容
会社名でも検索可能に変更。

具体的には
・今ある顧客名検索で会社名も検索できる様に変更。
・虫眼鏡アイコン追加
・検索や並び替え機能の復習ついでにコメントアウトを追加