### PR TITLE
CAPTCHA 検証追加

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,7 @@
 VITE_SUPABASE_URL = "https://zzqqcymhqrhtvzfwbfvu.supabase.co"
 VITE_SUPABASE_API_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp6cXFjeW1ocXJodHZ6ZndiZnZ1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDMzNDcwMDUsImV4cCI6MjA1ODkyMzAwNX0.2fhObmbcc3sMw845NBb9ce9pg_pLplpvRGesiVi_l5k"
+
+# vercelの環境変数に登録
+VITE_TURNSTILE_SITE_KEY = "0x4AAAAAABNnkK1jZj7LtRCO"
+# supabaseに登録
+VITE_TURNSTILE_SECRET_KEY = "0x4AAAAAABNnkH82fgcCJ1b_-bIYBX7WOrQ"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "simple-crm",
       "version": "0.0.0",
       "dependencies": {
+        "@marsidev/react-turnstile": "^1.1.0",
         "@radix-ui/react-alert-dialog": "^1.1.7",
         "@radix-ui/react-avatar": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.7",
@@ -1111,6 +1112,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@marsidev/react-turnstile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.1.0.tgz",
+      "integrity": "sha512-X7bP9ZYutDd+E+klPYF+/BJHqEyyVkN4KKmZcNRr84zs3DcMoftlMAuoKqNSnqg0HE7NQ1844+TLFSJoztCdSA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0 || ^19.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@marsidev/react-turnstile": "^1.1.0",
     "@radix-ui/react-alert-dialog": "^1.1.7",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.7",

--- a/src/modules/auth/auth.repository.ts
+++ b/src/modules/auth/auth.repository.ts
@@ -1,11 +1,11 @@
 import { supabase } from "@/lib/supabase";
 
 export const authRepository = {
-  async signup(name: string, email: string, password: string) {
+  async signup(name: string, email: string, password: string, captchaToken: string) {
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
-      options: { data: { name } },
+      options: { captchaToken, data: { name } },
     });
     if (error != null || data.user == null) throw new Error(error?.message);
     return {
@@ -14,10 +14,13 @@ export const authRepository = {
     };
   },
 
-  async signin(email: string, password: string) {
+  async signin(email: string, password: string, captchaToken: string) {
     const { data, error } = await supabase.auth.signInWithPassword({
       email,
-      password
+      password,
+      options: {
+        captchaToken
+      }
     });
     if (error != null || data.user == null) throw new Error(error?.message);
     return {
@@ -26,13 +29,9 @@ export const authRepository = {
     };
   },
 
+
   async guestSignin() {
-    const guestEmail = "guests@guests.com";
-    const guestPassword = "guests";
-    const { data, error } = await supabase.auth.signInWithPassword({
-      email: guestEmail,
-      password: guestPassword,
-    });
+    const { data, error } = await supabase.auth.signInAnonymously();
     if (error != null || data.user == null) throw new Error(error?.message);
     return {
       ...data.user,

--- a/src/pages/auth/Signin.tsx
+++ b/src/pages/auth/Signin.tsx
@@ -5,19 +5,25 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { authRepository } from "@/modules/auth/auth.repository";
 import { useCurrentUserStore } from "@/modules/auth/current-user.state";
+import { Turnstile } from "@marsidev/react-turnstile";
 
 const Signin = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [captchaToken, setCaptchaToken] = useState("");
   const currentUserStore = useCurrentUserStore();
 
+
   const signin = async () => {
-    const user = await authRepository.signin(email, password);
+    if (!captchaToken) return alert("認証を完了してください");
+
+    const user = await authRepository.signin(email, password, captchaToken);
     currentUserStore.set(user);
   };
 
   const guestSignin = async () => {
-    const user = await authRepository.guestSignin();  // ゲストログイン処理
+    // ゲストログイン処理
+    const user = await authRepository.guestSignin();
     currentUserStore.set(user);
   };
 
@@ -45,6 +51,14 @@ const Signin = () => {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
+
+            {/* Turnstile をここに挿入 */}
+            <Turnstile
+              siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
+              onSuccess={(token) => setCaptchaToken(token)}
+              className="w-full mt-2 rounded"
+            />
+
             <Button className="w-full" onClick={ signin } disabled={email === '' || password === ''}>
               ログイン
             </Button>


### PR DESCRIPTION
## 実装内容
Cloudflare Turnstile を用いた CAPTCHA検証 を追加

具体的には
・supabaseでCAPTCHA保護を有効にして、Cloudflare TurnstileでCAPTCHA検証をするためのコードを追加。

## 断念・妥協・未実装
未実装：Cloudflare Turnstileで登録したのは本番環境のドメインなので開発環境では動作未確認。

## メモ
supabaseがサポートしているCAPTCHA検証は以下の２つの様だったので、今回は Cloudflare Turnstile を使用。
・[Cloudflare Turnstile](https://www.cloudflare.com/products/turnstile/)
・[hCaptcha](https://www.hcaptcha.com/)

[Cloudflare Turnstileへの登録方法](https://kanrekigg.com/archives/10364#index_id12)
[supabaseドキュメント](https://supabase.com/docs/guides/auth/auth-captcha?queryGroups=captcha-method&captcha-method=turnstile-2#enable-captcha-protection-for-your-supabase-project)
⬇︎supabaseでの設定(Cloudflare Turnstileで作られるsecret_keyが必須)
[![Image from Gyazo](https://i.gyazo.com/b997d005ccf84e17023ce34e0a05d7de.png)](https://gyazo.com/b997d005ccf84e17023ce34e0a05d7de)