### PR TITLE
ゲストログインにもBot対策（Turnstile）を追加

### DIFF
--- a/src/modules/auth/auth.repository.ts
+++ b/src/modules/auth/auth.repository.ts
@@ -29,9 +29,12 @@ export const authRepository = {
     };
   },
 
-
-  async guestSignin() {
-    const { data, error } = await supabase.auth.signInAnonymously();
+  async guestSignin(captchaToken: string) {
+    const { data, error } = await supabase.auth.signInAnonymously({
+      options: {
+        captchaToken
+      }
+    });
     if (error != null || data.user == null) throw new Error(error?.message);
     return {
       ...data.user,

--- a/src/pages/auth/Signin.tsx
+++ b/src/pages/auth/Signin.tsx
@@ -22,8 +22,9 @@ const Signin = () => {
   };
 
   const guestSignin = async () => {
-    // ゲストログイン処理
-    const user = await authRepository.guestSignin();
+    if (!captchaToken) return alert("認証を完了してください");
+
+    const user = await authRepository.guestSignin(captchaToken);
     currentUserStore.set(user);
   };
 


### PR DESCRIPTION
## 実装内容
ゲストログインにも CAPTCHA検証 を追加

具体的には
・前回の変更でゲストログイン時には captchaToken を渡しておらず、動作しなかったためその修正。

## 断念・妥協・未実装
未実装：Cloudflare Turnstileで登録したのは本番環境のドメインなので開発環境では動作未確認。