### PR TITLE
開発環境ではCloudflare Turnstileを無効化

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,2 @@
+export const isProd = import.meta.env.MODE === "production";
+export const getCaptchaToken = (token: string) => isProd ? token : "dummy-token";

--- a/src/modules/auth/auth.repository.ts
+++ b/src/modules/auth/auth.repository.ts
@@ -1,11 +1,15 @@
 import { supabase } from "@/lib/supabase";
+import { getCaptchaToken } from "@/lib/env";
 
 export const authRepository = {
   async signup(name: string, email: string, password: string, captchaToken: string) {
     const { data, error } = await supabase.auth.signUp({
       email,
       password,
-      options: { captchaToken, data: { name } },
+      options: {
+        captchaToken: getCaptchaToken(captchaToken),
+        data: { name }
+      },
     });
     if (error != null || data.user == null) throw new Error(error?.message);
     return {
@@ -19,7 +23,7 @@ export const authRepository = {
       email,
       password,
       options: {
-        captchaToken
+        captchaToken: getCaptchaToken(captchaToken),
       }
     });
     if (error != null || data.user == null) throw new Error(error?.message);
@@ -32,7 +36,7 @@ export const authRepository = {
   async guestSignin(captchaToken: string) {
     const { data, error } = await supabase.auth.signInAnonymously({
       options: {
-        captchaToken
+        captchaToken: getCaptchaToken(captchaToken),
       }
     });
     if (error != null || data.user == null) throw new Error(error?.message);

--- a/src/pages/auth/Signin.tsx
+++ b/src/pages/auth/Signin.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { authRepository } from "@/modules/auth/auth.repository";
 import { useCurrentUserStore } from "@/modules/auth/current-user.state";
 import { Turnstile } from "@marsidev/react-turnstile";
+import { isProd } from "@/lib/env";
 
 const Signin = () => {
   const [email, setEmail] = useState("");
@@ -15,14 +16,15 @@ const Signin = () => {
 
 
   const signin = async () => {
-    if (!captchaToken) return alert("認証を完了してください");
+    // 本番環境かつcaptchaTokenがない時
+    if (isProd && !captchaToken) return alert("Cloudflare認証ができていません");
 
     const user = await authRepository.signin(email, password, captchaToken);
     currentUserStore.set(user);
   };
 
   const guestSignin = async () => {
-    if (!captchaToken) return alert("認証を完了してください");
+    if (isProd && !captchaToken) return alert("認証を完了してください");
 
     const user = await authRepository.guestSignin(captchaToken);
     currentUserStore.set(user);
@@ -54,11 +56,13 @@ const Signin = () => {
             />
 
             {/* Turnstile をここに挿入 */}
-            <Turnstile
-              siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
-              onSuccess={(token) => setCaptchaToken(token)}
-              className="w-full mt-2 rounded"
-            />
+            {isProd && (
+              <Turnstile
+                siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
+                onSuccess={(token) => setCaptchaToken(token)}
+                className="w-full mt-2 rounded"
+              />
+            )}
 
             <Button className="w-full" onClick={ signin } disabled={email === '' || password === ''}>
               ログイン

--- a/src/pages/auth/Signup.tsx
+++ b/src/pages/auth/Signup.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { authRepository } from "@/modules/auth/auth.repository";
 import { useCurrentUserStore } from "@/modules/auth/current-user.state";
 import { Turnstile } from "@marsidev/react-turnstile"; // Turnstileをインポート
+import { isProd } from "@/lib/env";
 
 const Signup = () => {
   const [name, setName] = useState("");
@@ -53,11 +54,15 @@ const Signup = () => {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
             />
-            <Turnstile
-              siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
-              onSuccess={(token) => setCaptchaToken(token)}
-              className="w-full mt-4 rounded"
-            />
+
+            {isProd && (
+              <Turnstile
+                siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
+                onSuccess={(token) => setCaptchaToken(token)}
+                className="w-full mt-4 rounded"
+              />
+            )}
+
             <Button
               className="w-full mt-4"
               onClick={signup}


### PR DESCRIPTION
## 実装内容
開発環境ではCloudflare Turnstileを無効化

具体的には
・Cloudflare Turnstileで登録しているのは本番環境のドメインなので、開発環境では Cloudflare Turnstile を使わないようにコードを修正。

## 問題
開発環境でも Cloudflare Turnstile を有効にするには、
Cloudflare Turnstileで localhost のドメインを許可するウィジェットを作り、
その secret_key をsupabaseに登録しなくてはいけない。

しかし、そうなると本番環境用と開発環境用で２つのsecret_keyが必要になるが、
supabaseに登録できるのは１プロジェクトにつき１つなので、
supabaseでも本番環境用と開発環境用の２プロジェクトを用意しなくてはいけなくなる。

今回は１つに抑えたいので開発環境で Cloudflare Turnstile を無効化し対処している。


## メモ
開発環境で動かす際には、supabaseで Attack Protection の Bot and Abuse Protection をOFFにする。