### PR TITLE
ゲストログイン時のユーザー情報表示を修正

### DIFF
--- a/src/components/sidebar/UserItem.tsx
+++ b/src/components/sidebar/UserItem.tsx
@@ -8,6 +8,8 @@ type Props = {
 };
 
 const UserItem: FC<Props> = ({ user }) => {
+  const name = user.user_metadata.name ?? "ゲストユーザー";
+
   return (
     <Card className="bg-gray-700 border-none text-white mx-2 mb-4">
       <CardContent className="px-3 pt-1 pb-2.5 flex items-center gap-1">
@@ -21,12 +23,12 @@ const UserItem: FC<Props> = ({ user }) => {
         </Avatar>
 
         {/* 名前とメール */}
-        <div>
+        <div className="pt-0.5">
           <div className="text-md tracking-wider">
-            {user.user_metadata.name}
+            {name}
           </div>
           <div className="text-xs font-thin text-gray-300">
-            {user.email}
+            {user.email || "no_email_address"}
           </div>
         </div>
       </CardContent>

--- a/src/pages/auth/Signup.tsx
+++ b/src/pages/auth/Signup.tsx
@@ -63,10 +63,11 @@ const Signup = () => {
               />
             )}
 
+            {/* captchaTokenも必要としているため本番環境でのみ登録可能 */}
             <Button
               className="w-full mt-4"
               onClick={signup}
-              disabled={name === "" || email === "" || password === "" || !captchaToken} // 入力値とCaptchaをチェック
+              disabled={name === "" || email === "" || password === "" || !captchaToken}
             >
               登録
             </Button>


### PR DESCRIPTION
## 実装内容
ゲストログイン時のユーザー情報表示を修正

具体的には
・ゲストログインの場合userのnameやemailを参照できないので、そんな時にsidebarのUserItemには「ゲストユーザー」と表示されるように変更